### PR TITLE
Fix list indent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,8 @@ The interface exposes:
     - we subscribe to each of these in the `Presenter`'s one lifecycle method, `onViewAttached`
     - each subscription is added to a `CompositeSubscription` via the method `unsubscribeOnViewDetach`, which will unsubscribe from all subscriptions when the view is detached
     - we limit what the `Presenter` is exposed to by using a return type of `Observable<Void>`, often it's enough just to know the action has happened
-- actions which immediately update the view with a simple operation e.g. show or hide a progress bar (method name will usually starts with `show`/`hide`), or methods which `set` data/state 
-- actions that start another Activity (prefixed with `goTo` e.g. `goToGif`)
+ - actions which immediately update the view with a simple operation e.g. show or hide a progress bar (method name will usually starts with `show`/`hide`), or methods which `set` data/state 
+ - actions that start another Activity (prefixed with `goTo` e.g. `goToGif`)
 
 ## Separating loading state from data availability 
 


### PR DESCRIPTION
Fix rendered list indent to match intended indent (inferred from markdown source) :)

Before:

<img width="917" alt="screen shot 2016-06-06 at 7 22 21 am" src="https://cloud.githubusercontent.com/assets/6463980/15820565/4d4798a2-2bb8-11e6-8f3d-c5dd8dbf7867.png">

After:

<img width="912" alt="screen shot 2016-06-06 at 7 28 52 am" src="https://cloud.githubusercontent.com/assets/6463980/15820572/50fe540e-2bb8-11e6-9411-f336f3bd3f50.png">
