### PR TITLE
Update log tag to be class name; respect char limit

### DIFF
--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingNetworkManager.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingNetworkManager.java
@@ -51,13 +51,13 @@ class TrendingNetworkManager {
                 .map(listResult -> listResult.response().body().gifs())
                 .doOnNext(trendingGifsRelay::call)
                 .subscribe(ignored -> loadingStateRelay.call(LoadingState.IDLE),
-                        throwable -> Log.e("TrendingGifNetworkManager",
+                        throwable -> Log.e("TrendingNetworkManager",
                                 "Failed to parse and show latest trending gifs",
                                 throwable)));
 
         subscription.add(result.filter(Funcs.not(Results.isSuccessful()))
                 .subscribe(ignored -> loadingStateRelay.call(LoadingState.ERROR),
-                        throwable -> Log.e("TrendingGifNetworkManager",
+                        throwable -> Log.e("TrendingNetworkManager",
                                 "Failed to retrieve latest trending gifs",
                                 throwable)));
     }


### PR DESCRIPTION
Log tag did not match class name, and exceeded 23 character length limit. Updated to fix both issues.
