### PR TITLE
Bugfix: Disable pull-to-refresh during initial data fetch

### DIFF
--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingActivity.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingActivity.java
@@ -113,6 +113,10 @@ public class TrendingActivity extends BaseActivity<TrendingPresenter.View, Trend
         swipeRefreshLayout.setRefreshing(false);
     }
 
+    @Override public void setIncrementalLoadingEnabled(boolean enabled) {
+        swipeRefreshLayout.setEnabled(enabled);
+    }
+
     @Override public void goToGif(@NonNull final Gif gif) {
         GifDetailActivity.start(this, gif);
     }

--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
@@ -44,12 +44,15 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
                     if (loadingState == LOADING) {
                         if (data == null) {
                             view.showLoading();
+                            view.setIncrementalLoadingEnabled(false);
                         } else {
                             view.showIncrementalLoading();
                         }
                     } else {
+                        // Have data or error
                         view.hideLoading();
                         view.hideIncrementalLoading();
+                        view.setIncrementalLoadingEnabled(true);
 
                         if (loadingState == IDLE) {
                             if (data == null) {
@@ -97,6 +100,8 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
 
         void showIncrementalLoading();
         void hideIncrementalLoading();
+        /** Useful to disable pull-to-refresh during initial data fetch. */
+        void setIncrementalLoadingEnabled(boolean enabled);
 
         void goToGif(@NonNull final Gif gif);
     }


### PR DESCRIPTION
When fetching the initial data after app start, it is possible to pull at the top of the screen and see two loading indicators at the same time:

<img width="520" alt="screenshot 2017-07-27 11 42 05" src="https://user-images.githubusercontent.com/346214/28665028-8bee559e-72c2-11e7-8734-c03b32fa41f2.png">

This is not a common UI pattern and as a user I found it a bit confusing so my guess is this is a bug, please correct me if this behaviour is intentional.

Sending this as an RFC, happy to update the `TrendingPresenterTest` if you like this PR.

**Test Plan**

All tests in `TrendingPresenterTest` pass.

The app works as before but pull-to-refresh is only enabled once we're showing data or error.

Cannot pull to refresh:

<img width="520" alt="screenshot 2017-07-27 11 52 30" src="https://user-images.githubusercontent.com/346214/28665127-e696f046-72c2-11e7-91c6-337b37801134.png">

Can pull to refresh once data is loaded:

<img width="520" alt="screenshot 2017-07-27 11 53 05" src="https://user-images.githubusercontent.com/346214/28665138-f3ffd090-72c2-11e7-930b-0d6be67c79e3.png">

