### PR TITLE
RFC: Simplify logic around showing pull-to-refresh indicator

### DIFF
--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingActivity.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingActivity.java
@@ -105,10 +105,6 @@ public class TrendingActivity extends BaseActivity<TrendingPresenter.View, Trend
         loadingProgressBar.setVisibility(View.GONE);
     }
 
-    @Override public void showIncrementalLoading() {
-        swipeRefreshLayout.setRefreshing(true);
-    }
-
     @Override public void hideIncrementalLoading() {
         swipeRefreshLayout.setRefreshing(false);
     }

--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
@@ -33,6 +33,8 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
 
         trendingNetworkManager.setup();
 
+        view.showLoading();
+
         addToAutoUnsubscribe(Observable.combineLatest(trendingNetworkManager.onLoadingStateChanged(),
                 trendingNetworkManager.onDataChanged().startWith(Observable.just(null)),
                 LoadingStateWithData::create)
@@ -42,12 +44,9 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
                     final List<Gif> data = loadingStateWithData.trendingGifs();
 
                     if (loadingState == LOADING) {
-                        if (data == null) {
-                            view.showLoading();
-                        } else {
-                            view.showIncrementalLoading();
-                        }
+                        // Do nothing, we've shown the loading indicator before doing the request
                     } else {
+                        // Have data or error
                         view.hideLoading();
                         view.hideIncrementalLoading();
 
@@ -95,7 +94,7 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
         void showLoading();
         void hideLoading();
 
-        void showIncrementalLoading();
+        // No need to show incremental loading, this is done automatically by the Android UI
         void hideIncrementalLoading();
 
         void goToGif(@NonNull final Gif gif);

--- a/app/src/test/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenterTest.java
+++ b/app/src/test/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenterTest.java
@@ -78,15 +78,6 @@ public class TrendingPresenterTest
         verify(view).showLoading();
     }
 
-    @Test public void onLoadingStateChanged_withData_showIncrementalLoading() throws Exception {
-        presenterOnViewAttached();
-
-        dataChangedRelay.call(Collections.singletonList(mock(Gif.class)));
-        loadingStateChangedRelay.call(LoadingState.LOADING);
-
-        verify(view).showIncrementalLoading();
-    }
-
     @Test public void onLoadingStateChanged_noData_idleAfterLoading_hideLoading() throws Exception {
         presenterOnViewAttached();
 


### PR DESCRIPTION
The `showIncrementalLoading` method is unnecessary. The UI uses `SwipeRefreshLayout` which automatically shows the loading indicator when the user swipes down.

Also moved the call to `showLoading` because we only want to show the "fetching data" `ProgressBar` once. We'll never get to a state when we should show it again. Once the initial fetch completes we're either showing data or an error and in both cases we can pull to refresh - this will show the incremental loading indicator, not the `ProgressBar`.

**Test Plan**

`TrendingPresenterTest` passes.

The app works exactly as before.

Shows a loading indicator on initial fetch:

<img width="520" alt="screenshot 2017-07-27 12 04 43" src="https://user-images.githubusercontent.com/346214/28665841-4ce01998-72c5-11e7-9f96-c92900785082.png">

It is possible to pull to refresh like before:

<img width="520" alt="screenshot 2017-07-27 12 09 08" src="https://user-images.githubusercontent.com/346214/28665856-570ef70e-72c5-11e7-97a4-52addeff1d4a.png">

