### PR TITLE
Always log error stack traces

### DIFF
--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingNetworkManager.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingNetworkManager.java
@@ -50,16 +50,16 @@ class TrendingNetworkManager {
         subscription.add(result.filter(Results.isSuccessful())
                 .map(listResult -> listResult.response().body().gifs())
                 .doOnNext(trendingGifsRelay::call)
-                .subscribe(ignored -> loadingStateRelay.call(LoadingState.IDLE),
-                        throwable -> Log.e("TrendingNetworkManager",
-                                "Failed to parse and show latest trending gifs",
-                                throwable)));
+                .subscribe(
+                        ignored -> loadingStateRelay.call(LoadingState.IDLE),
+                        e -> Log.e("TrendingNetworkManager",
+                                "Failed to parse and show latest trending GIFs", e)));
 
         subscription.add(result.filter(Funcs.not(Results.isSuccessful()))
-                .subscribe(ignored -> loadingStateRelay.call(LoadingState.ERROR),
-                        throwable -> Log.e("TrendingNetworkManager",
-                                "Failed to retrieve latest trending gifs",
-                                throwable)));
+                .subscribe(
+                        ignored -> loadingStateRelay.call(LoadingState.ERROR),
+                        e -> Log.e("TrendingNetworkManager",
+                                "Failed to retrieve latest trending GIFs", e)));
     }
 
     void refresh() {

--- a/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
+++ b/app/src/main/java/com/emmaguy/giphymvp/feature/trending/TrendingPresenter.java
@@ -65,12 +65,13 @@ class TrendingPresenter extends BasePresenter<TrendingPresenter.View> {
                             }
                         }
                     }
-                }, throwable -> Log.e("TrendingPresenter", "Failed to update UI")));
+                }, e -> Log.e("TrendingPresenter", "Failed to update UI", e)));
 
         addToAutoUnsubscribe(view.onRefreshAction()
                 .startWith(Observable.just(null))
-                .subscribe(ignored -> trendingNetworkManager.refresh(),
-                        throwable -> Log.e("TrendingPresenter", "Failed to refresh")));
+                .subscribe(
+                        ignored -> trendingNetworkManager.refresh(),
+                        e -> Log.e("TrendingPresenter", "Failed to refresh", e)));
 
         addToAutoUnsubscribe(view.onGifClicked().subscribe(view::goToGif));
     }


### PR DESCRIPTION
There were two call sites where we get an error, log an error message but not the actual error.

It is often useful to see the `Throwable` message and stack trace in logs.

RFC: Also named the variable `e`, it is shorter than `throwable` and common in Java (most Android developers have seen `catch (Exception e)` before).

**Test Plan**

The app compiles and runs.